### PR TITLE
Fix broken links for Staff Software Enginnering Blog

### DIFF
--- a/posts/Staff-Software-Engineer.mdx
+++ b/posts/Staff-Software-Engineer.mdx
@@ -17,19 +17,6 @@ tags: Promotions
   allowfullscreen
 ></iframe>
 
-- [My Path to Becoming a Staff Engineer](#heading-my-path-to-becoming-a-staff-engineer)
-- [What is a Staff Engineer?](#heading-what-is-a-staff-engineer)
-- [Story Time: Building Font Selection in Slack](#heading-story-time-building-font-selection-in-slack)
-- [The Key Differences between Staff Engineers and Senior Engineers](#heading-the-key-differences-between-staff-engineers-and-senior-engineers)
-- [Staff Engineer vs Manager Role Differences](#heading-staff-engineer-vs-manager-role-differences)
-- [Why You Might Not Be Promoted Yet](#heading-why-you-might-not-be-promoted-yet)
-- [How to Become a Staff Engineer](#heading-how-to-become-a-staff-engineer)
-- [Evaluation Criteria](#heading-evaluation-criteria)
-- [Building Your Staff Engineer Portfolio](#heading-building-your-staff-engineer-portfolio)
-- [The Promotion Process](#heading-the-promotion-process)
-- [A Six-Month Plan to Get Promoted](#heading-a-six-month-plan-to-get-promoted)
-- [Wrapping Up](#heading-wrapping-up)
-
 Navigating the journey from senior engineer to staff engineer can be daunting. Promotions are often confusing, and this particular leap can feel even more ambiguous.
 
 As someone who has successfully transitioned to a Staff Engineer role, I want to share my insights and experiences to help you on this journey.
@@ -42,10 +29,6 @@ In this article, I’ll address key questions you might have, like:
 - Who do you talk to for guidance?
 
 I’ll also share my personal story and a structured six-month plan to help you achieve your goals. Let’s dive in!
-
-If you prefer to watch this as a video, check this out
-
-%[https://www.youtube.com/watch?v=CpiR7qznMBc]
 
 ## My Path to Becoming a Staff Engineer
 
@@ -81,7 +64,10 @@ This project was a classic example of a greenfield initiative: it had never been
 
 Being a technical leader on such a project was both challenging and rewarding. It stretched my skills and reinforced the importance of cross-functional teamwork and technical vision in delivering high-impact features.
 
-![Font selection feature in Slack](https://shrutikapoor.dev/images/staff-software-engineer/slack-font-selection-screenshot.jpg align="center")
+<img
+  src="/images/staff-software-engineer/slack-font-selection-screenshot.jpg"
+  style={{ margin: 'auto' }}
+/>
 
 ## The Key Differences between Staff Engineers and Senior Engineers
 
@@ -115,7 +101,7 @@ The fundamental distinction:
 
 In most organizations, Staff Engineering and Management represent two distinct career advancement paths, allowing technical professionals to grow in seniority and impact without transitioning into people management roles.
 
-![Introduction to Staff Engineering - Alex Ewerlöf Notes](https://substackcdn.com/image/fetch/$s_!FOSi!,f_auto,q_auto:good,fl_progressive:steep/https%3A%2F%2Fsubstack-post-media.s3.amazonaws.com%2Fpublic%2Fimages%2F3dd518bd-6083-4101-bfa7-31bc0b80f16a_1146x1150.png align="left")
+![Introduction to Staff Engineering - Alex Ewerlöf Notes](https://substackcdn.com/image/fetch/$s_!FOSi!,f_auto,q_auto:good,fl_progressive:steep/https%3A%2F%2Fsubstack-post-media.s3.amazonaws.com%2Fpublic%2Fimages%2F3dd518bd-6083-4101-bfa7-31bc0b80f16a_1146x1150.png)
 
 ## Why You Might Not Be Promoted Yet
 
@@ -147,7 +133,16 @@ You can do hard things!
 
 I made a detailed video highlighting strategies to overcome imposter syndrome. You can check it out here:
 
-%[https://www.youtube.com/watch?v=2n6Mu39Q3m4]
+<iframe
+  width="720"
+  height="360"
+  src="https://www.youtube.com/embed/2n6Mu39Q3m4?si=R1b0Ts8BxP39hsYB"
+  title="YouTube video player"
+  frameborder="0"
+  allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
+  referrerpolicy="strict-origin-when-cross-origin"
+  allowfullscreen
+></iframe>
 
 ### Waiting to Become a Deep Technical Expert
 


### PR DESCRIPTION
- Now all the links are fixed.

[x] Removed `Table of Contents` due to the hyperlink issue.
[x] Fixed "Slack Font Selection" screenshot render.
[x] Fixed "Introduction to Staff Engineering - Alex Ewerlöf Notes" screenshot render.
[x] Added Iframe element for "Imposter Syndrome Video".